### PR TITLE
fix typo: capitalize Ethereum in index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,6 @@ In addition, we have also developed OP Stack related tools.
 
 Meanwhile, we also contributed in other community projects.
 
-- [Shisui](https://github.com/optimism-java/shisui) is an ethereum portal network client written in Go.
+- [Shisui](https://github.com/optimism-java/shisui) is an Ethereum portal network client written in Go.
 
 - [Mev-share-java](https://github.com/optimism-java/mev-share-java) is a Java client library for Flashbots MEV-share Matchmaker.


### PR DESCRIPTION
Fixed a typo in docs/index.md by correcting "ethereum" to "Ethereum".